### PR TITLE
def'd out some Windows and MSVC specifics, added SCons build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,0 +1,5 @@
+import os
+
+environment = Environment(ENV = os.environ)
+
+SConscript(dirs = ["minisphere"], exports = "environment")

--- a/minisphere/SConscript
+++ b/minisphere/SConscript
@@ -1,0 +1,3 @@
+Import("environment")
+
+minisphere = environment.Program("minisphere", ["sphere_api.c", "duktape.c", "main.c"], LIBS = "allegro")

--- a/minisphere/minisphere.h
+++ b/minisphere/minisphere.h
@@ -1,7 +1,9 @@
+#ifdef _MSC_VER
 #define _CRT_SECURE_NO_WARNINGS
+#include <malloc.h>
+#endif
 
 #include <stdlib.h>
-#include <malloc.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <time.h>


### PR DESCRIPTION
I added some SCons build files, #defed out some of the MSVC-specifics and Windows specifics.

In main.c:29, you don't need to and shouldn't accept case insensitive arguments.
In either case, stricmp is NOT a pure C function, it is a Microsoft-specific. Its analogous function is strcasecmp in BSD and GNU, but even then those are not standardized functions.

I moved the check for a rooted path into an inline function and added system-specific defines.
