### PR TITLE
Fixed ANSI mode build, added SCons files

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,0 +1,5 @@
+import os
+
+environment = Environment(ENV = os.environ)
+
+SConscript(dirs = ["minisphere"], exports = "environment")

--- a/minisphere/SConscript
+++ b/minisphere/SConscript
@@ -1,0 +1,7 @@
+Import("environment")
+
+allegro_libs = ["allegro", "allegro_audio", "allegro_ttf", "allegro_image", "allegro_main", "allegro_acodec", "allegro_dialog", "allegro_font", "allegro_primitives"]
+
+minisphere_files = ["api.c", "color.c", "duktape.c", "font.c", "image.c", "input.c", "log.c", "main.c", "map_engine.c", "person.c", "rfn_handler.c", "sound.c", "spriteset.c", "surface.c", "windowstyle.c"]
+
+minisphere = environment.Program("minisphere", minisphere_files, LIBS = allegro_libs, CFLAGS = " -ansi -g ")

--- a/minisphere/api.c
+++ b/minisphere/api.c
@@ -298,7 +298,7 @@ duk_GetFileList(duk_context* ctx)
 	i = 0;
 	if (al_get_fs_entry_mode(fs) & ALLEGRO_FILEMODE_ISDIR && al_open_directory(fs)) {
 		duk_push_array(ctx);
-		while (file_info = al_read_directory(fs)) {
+		while ((file_info = (ALLEGRO_FS_ENTRY*)al_read_directory(fs))) {
 			if (al_get_fs_entry_mode(file_info) & ALLEGRO_FILEMODE_ISFILE) {
 				file_path = al_create_path(al_get_fs_entry_name(file_info));
 				duk_push_string(ctx, al_get_path_filename(file_path)); duk_put_prop_index(ctx, -2, i);

--- a/minisphere/color.c
+++ b/minisphere/color.c
@@ -1,6 +1,7 @@
 #include "minisphere.h"
 #include "api.h"
 #include "color.h"
+#include <math.h>
 
 static duk_ret_t _js_CreateColor(duk_context* ctx);
 static duk_ret_t _js_BlendColors(duk_context* ctx);

--- a/minisphere/color.c
+++ b/minisphere/color.c
@@ -44,9 +44,9 @@ _js_CreateColor(duk_context* ctx)
 	int           n_args;
 	
 	n_args = duk_get_top(ctx);
-	color.r = duk_to_int(ctx, 0) / 255.0; color.r = min(max(color.r, 0.0), 1.0);
-	color.g = duk_to_int(ctx, 1) / 255.0; color.g = min(max(color.g, 0.0), 1.0);
-	color.b = duk_to_int(ctx, 2) / 255.0; color.b = min(max(color.b, 0.0), 1.0);
+	color.r = duk_to_int(ctx, 0) / 255.0; color.r = fmin(fmax(color.r, 0.0), 1.0);
+	color.g = duk_to_int(ctx, 1) / 255.0; color.g = fmin(fmax(color.g, 0.0), 1.0);
+	color.b = duk_to_int(ctx, 2) / 255.0; color.b = fmin(fmax(color.b, 0.0), 1.0);
 	color.a = n_args > 3 ? duk_to_int(ctx, 3) / 255.0 : 1.0; color.a = min(max(color.a, 0.0), 1.0);
 	duk_push_sphere_color(ctx, color);
 	return 1;

--- a/minisphere/color.c
+++ b/minisphere/color.c
@@ -47,7 +47,7 @@ _js_CreateColor(duk_context* ctx)
 	color.r = duk_to_int(ctx, 0) / 255.0; color.r = fmin(fmax(color.r, 0.0), 1.0);
 	color.g = duk_to_int(ctx, 1) / 255.0; color.g = fmin(fmax(color.g, 0.0), 1.0);
 	color.b = duk_to_int(ctx, 2) / 255.0; color.b = fmin(fmax(color.b, 0.0), 1.0);
-	color.a = n_args > 3 ? duk_to_int(ctx, 3) / 255.0 : 1.0; color.a = min(max(color.a, 0.0), 1.0);
+	color.a = n_args > 3 ? duk_to_int(ctx, 3) / 255.0 : 1.0; color.a = fmin(fmax(color.a, 0.0), 1.0);
 	duk_push_sphere_color(ctx, color);
 	return 1;
 }

--- a/minisphere/main.c
+++ b/minisphere/main.c
@@ -241,7 +241,7 @@ end_frame(int framerate)
 		s_last_frame_time = clock();
 		s_frame_skips = 0;
 		if (s_take_screenshot) {
-			sprintf(filename, "snapshot-%i.png", time(NULL));
+			sprintf(filename, "snapshot-%i.png", (int)time(NULL));
 			path = get_asset_path(filename, "screenshots", true);
 			screenshot = al_create_bitmap(g_res_x, g_res_y);
 			al_set_target_bitmap(screenshot);

--- a/minisphere/main.c
+++ b/minisphere/main.c
@@ -410,7 +410,7 @@ on_error:
 static void
 on_duk_fatal(duk_context* ctx, duk_errcode_t code, const char* msg)
 {
-	al_show_native_message_box(g_display, "Script Error", msg, NULL, NULL, ALLEGRO_MESSAGEBOX_ERROR);
+	al_show_native_message_box(g_display, "Script Error", "", msg, NULL, ALLEGRO_MESSAGEBOX_ERROR);
 	shutdown_engine();
 	exit(0);
 }

--- a/minisphere/main.c
+++ b/minisphere/main.c
@@ -428,7 +428,7 @@ handle_js_error()
 		duk_get_prop_string(g_duktape, -2, "fileName");
 		const char* file_path = duk_get_string(g_duktape, -1);
 		if (file_path != NULL) {
-			char* file_name = strrchr(file_path, '/');
+			const char* file_name = strrchr(file_path, '/');
 			file_name = file_name != NULL ? (file_name + 1) : file_path;
 			duk_push_sprintf(g_duktape, "%s (line %d)\n\n%s", file_name, (int)line_num, err_msg);
 		}

--- a/minisphere/rfn_handler.c
+++ b/minisphere/rfn_handler.c
@@ -66,24 +66,28 @@ al_load_rfn_font(const char* filename, int size, int flags)
 		uint8_t* dest_ptr = bitmap_lock->data;
 		switch (rfn->header.version) {
 		case 1: // version 1: 8-bit grayscale glyphs
-			for (int y = 0; y < glyph->header.height; ++y) {
-				for (int x = 0; x < glyph->header.width; ++x) {
-					dest_ptr[x] = src_ptr[x];
-					dest_ptr[x + 1] = src_ptr[x];
-					dest_ptr[x + 2] = src_ptr[x];
-					dest_ptr[x + 3] = 255;
-					dest_ptr += 4;
-				}
-				dest_ptr += bitmap_lock->pitch - (glyph->header.width * 4);
-				src_ptr += glyph->header.width;
-			}
+            {
+                for (int y = 0; y < glyph->header.height; ++y) {
+                    for (int x = 0; x < glyph->header.width; ++x) {
+                        dest_ptr[x] = src_ptr[x];
+                        dest_ptr[x + 1] = src_ptr[x];
+                        dest_ptr[x + 2] = src_ptr[x];
+                        dest_ptr[x + 3] = 255;
+                        dest_ptr += 4;
+                    }
+                    dest_ptr += bitmap_lock->pitch - (glyph->header.width * 4);
+                    src_ptr += glyph->header.width;
+                }
+            }
 			break;
 		case 2: // version 2: 32-bit truecolor glyphs
-			for (int y = 0; y < glyph->header.height; ++y) {
-				memcpy(dest_ptr, src_ptr, glyph->header.width * 4);
-				dest_ptr += bitmap_lock->pitch;
-				src_ptr += glyph->header.width * pixel_size;
-			}
+            {
+                for (int y = 0; y < glyph->header.height; ++y) {
+                    memcpy(dest_ptr, src_ptr, glyph->header.width * 4);
+                    dest_ptr += bitmap_lock->pitch;
+                    src_ptr += glyph->header.width * pixel_size;
+                }
+            }
 			break;
 		}
 		al_unlock_bitmap(glyph->bitmap);


### PR DESCRIPTION
In ANSI mode, the declaration of `y' leaks out of the for() loop.

Adding extra scoping fixes this in a relatively inoffensive way.

in api.c:301, something needs to be done about actually being const-correct. I just casted so that the error would go away because I don't know enough about that functions, but no good will come of that.

I changed the calls to `min` and `max` to the functions `fmin` and `fmax`. `min` and `max` are MSVC extensions. Alternatively you could include tgmath, but there's no real reason to with actual floating point numbers.
