### PR TITLE
Add table formatting to Kami profiler output and fix bugs

### DIFF
--- a/assets/system/game_modules/kami.mjs
+++ b/assets/system/game_modules/kami.mjs
@@ -30,34 +30,94 @@
  *  POSSIBILITY OF SUCH DAMAGE.
 **/
 
-import from from 'from';
+const now = SSj.now;
 
 export default new
 class Kami
 {
-	constructor(title = Sphere.Game.name)
+	constructor()
 	{
-		this.enabled = SSj.now() > 0;
-		this.title = title;
+		this.enabled = now() > 0;
 		this.records = [];
+		this.outputBordered = false;
+		this.placeholder = new Record();
 		if (this.enabled)
 			this.exitJob = Dispatch.onExit(() => this.finish());
 	}
 
 	finish()
 	{
-		SSj.log(`Profiling has completed for "${this.title}"`);
-		let sortedRecords = from(this.records)
-			.where(it => it.count > 0)
-			.descending(it => it.totalTime / it.count);
-		for (const record of sortedRecords) {
-			let averageTime = Math.round(record.totalTime / record.count / 1000).toLocaleString();
-			let count = record.count.toLocaleString();
-			let totalTime = Math.round(record.totalTime / 1000).toLocaleString();
-			SSj.log(`  ${count} occurrences "${record.description}" took ${totalTime} mcs (avg. ${averageTime} mcs)`);
-			record.target[record.methodName] = record.originalFunction;
-		}
+		if (!this.enabled)
+			return; //in case someone manually calls this
+		
 		this.exitJob.cancel();
+		let totalTime = 0;
+		let totalAverage = 0;
+		let calls = 0;
+		for (const record of this.records) {
+			if (record.count > 0) {
+				record.averageTime = record.totalTime / record.count;
+				calls += record.count;
+				totalTime += record.totalTime;
+				totalAverage += record.averageTime;
+			}
+		}
+		this.records.sort(function(a, b) { return b.averageTime - a.averageTime; });
+
+		let consoleOutput = [
+			[ "Event" ],
+			[ "Calls" ],
+			[ "Time (us)" ],
+			[ "% Total" ],
+			[ "Avg (us)" ],
+			[ "% Avg" ],
+		];
+		for (const record of this.records) {
+			if (record.count > 0) {
+				consoleOutput[0].push(record.description);
+				consoleOutput[1].push(record.count.toLocaleString());
+				consoleOutput[2].push(Math.round(record.totalTime / 1000).toLocaleString());
+				consoleOutput[3].push(Math.round(100 * record.totalTime / totalTime) + "%");
+				consoleOutput[4].push(Math.round(record.averageTime / 1000).toLocaleString());
+				consoleOutput[5].push(Math.round(100 * record.averageTime / totalAverage) + "%");
+			}
+			if (record.attached === true)
+				record.target[record.methodName] = record.originalFunction;
+		}
+		consoleOutput[0].push("Total");
+		consoleOutput[1].push(calls.toLocaleString());
+		consoleOutput[2].push(Math.round(totalTime / 1000).toLocaleString());
+		consoleOutput[3].push("100%");
+		consoleOutput[4].push(Math.round(totalAverage / 1000).toLocaleString());
+		consoleOutput[5].push("100%");
+
+
+		SSj.log(`Profiling results for "${Sphere.Game.name}"\n` + makeTable(consoleOutput, this.outputBordered));
+		this.records.splice(0, this.records.length);
+	}
+
+	begin(description = "Unknown")
+	{
+		if (!this.enabled)
+			return this.placeholder;
+		
+		let record = findRecord(this.records, description);
+		if(record === undefined) {
+			record = new Record(description, false, undefined, undefined, undefined);
+			this.records.push(record);
+		}
+		if (record.startTime > 0)
+			throw new Error("Attempt to profile re-entrant block - this is not supported");
+		record.startTime = now();
+		return record;
+	}
+
+	end(record)
+	{
+		let end = now();
+		record.totalTime += end - record.startTime;
+		record.startTime = 0;
+		++record.count;
 	}
 
 	profile(target, methodName, description)
@@ -66,25 +126,94 @@ class Kami
 			return;
 
 		let originalFunction = target[methodName];
-		let record = {
-			description: `${target.constructor.name}#${methodName}`,
-			count: 0,
-			methodName,
-			originalFunction,
-			target,
-			totalTime: 0,
-		}
+		let record = new Record(`${target.constructor.name}#${methodName}`,
+			true, methodName, originalFunction, target);
+
 		if (typeof description === 'string')
 			record.description = description;
 
 		target[methodName] = function (...args) {
-			let startTime = SSj.now();
-			originalFunction.apply(this, args);
-			let endTime = SSj.now();
-			record.totalTime += endTime - startTime;
+			let startTime = now();
+			let result = originalFunction.apply(this, args);
+			record.totalTime += now() - startTime;
 			++record.count;
-		}
-
+			return result;
+		};
 		this.records.push(record);
 	}
+};
+
+//constructor function used for Record objects to limit risk of introducing multiple types
+//don't want profiler to accidently trigger a Jit bailout (relevant as these can be created
+//in two places)
+//ES5 style constructor as simple/short and class construction is slightly slower in CC
+function Record (description, attached, methodName, originalFunction, target)
+{
+	this.description = description;
+	this.attached = attached;
+	this.count = 0;
+	this.methodName = methodName;
+	this.originalFunction = originalFunction;
+	this.target = target;
+	this.startTime = attached ? 1 : 0;
+	this.totalTime = 0;
+	this.averageTime = 0;
+}
+
+function findRecord(records, description)
+{
+	let i = 0;
+	let length = records.length;
+	for (; i < length && records[i].description !== description; ++i);
+	return i < length ? records[i] : undefined;
+}
+
+function makeTable(table, bordered)
+{
+	let totalLength = 1;
+	let rows = table[0].length;
+	let columns = table.length;
+	let output = "";
+
+	for (let i = 0; i < table.length; ++i) {
+		let width = 0;
+		const column = table[i];
+		for (const value of column) {
+			width = Math.max(width, value.length);
+		}
+		for (let j = 0; j < rows; ++j) {
+			if (i > 0)
+				column[j] = " " + column[j].padStart(width) + " ";
+			else
+				column[j] = column[j].padEnd(width) + " ";
+			if (bordered === true)
+				column[j] += "|";
+		}
+		totalLength += (width + 3);
+	}
+
+	let start = "\n";
+	let line = "";
+	let startLine = "";
+	if (bordered === true) {
+		start = "\n|";
+		line = "\n" + ("-".repeat(totalLength - 1));
+	}
+	else {
+		startLine = "\n" + ("-".repeat(totalLength - 1));
+	}
+	
+	for (let i = 0; i < rows; ++i) {
+		if (i === rows - 1)
+			output += startLine;
+
+		output += line + start;
+		for (let j = 0; j < columns; ++j)
+			output += table[j][i];
+
+		if (i === 0)
+			output += startLine;
+	}
+	output += line;
+	return output;
 }


### PR DESCRIPTION
1. Fix error where the .profile() method would prevent profiled functions from returning values
2. Fix error where the results could be output twice if user manually called .finish() in code and closed spheRun whilst it was running
3. Add early return to .finish() for miniSphere in case user manually calls it (wouldn't have had visible output but would have wasted time)
4. Add Percentages to output - reworked finish function signifciantly to do this - note use of from removed as had to iterate over array twice anyway
5. Added table output - either with or without borders - default is without borders to be short for command line
6. Added .start() and .end() methods for profiling half a function or global code etc.
7. Refactored record objects with a constructor function to enforce same layout between .start() and .profile() if any future updates occur (avoid accidental bailout triggers)