### PR TITLE
Refactor image.mjs to improve performance

### DIFF
--- a/assets/system/game_modules/image.mjs
+++ b/assets/system/game_modules/image.mjs
@@ -32,6 +32,9 @@
 
 import from from 'from';
 
+const white = Color.White;
+let color = null;
+
 let imageShader = new Shader({
 	fragmentFile: '#/shaders/image.frag.glsl',
 	vertexFile:   '#/shaders/image.vert.glsl',
@@ -52,13 +55,18 @@ class Image
 		let texture = new Texture(fullPath);
 		let shape = new Shape(ShapeType.TriStrip, texture,
 			new VertexList([
-				{ x: 0, y: 0, u: 0, v: 1 },
-				{ x: 1, y: 0, u: 1, v: 1 },
-				{ x: 0, y: 1, u: 0, v: 0 },
-				{ x: 1, y: 1, u: 1, v: 0 },
+				{ x: 0,             y: 0,              u: 0, v: 1 },
+				{ x: texture.width, y: 0,              u: 1, v: 1 },
+				{ x: 0,             y: texture.height, u: 0, v: 0 },
+				{ x: texture.width, y: texture.height, u: 1, v: 0 },
 			]));
+		
+		this._x = 0;
+		this._y = 0;
 
 		this.model = new Model([ shape ], imageShader);
+		this.transform = new Transform();
+		this.model.transform = this.transform;
 		this.texture = texture;
 	}
 
@@ -72,12 +80,17 @@ class Image
 		return this.texture.width;
 	}
 
-	blitTo(surface, x, y, tintColor = Color.White)
+	blitTo(surface, x, y, tintColor = white)
 	{
-		imageShader.setColorVector('tintColor', tintColor);
-		this.model.transform = new Transform()
-			.scale(this.texture.width, this.texture.height)
-			.translate(x, y);
+		if (color !== tintColor) {
+			imageShader.setColorVector('tintColor', tintColor);
+			color = tintColor;
+		}
+		if (this._x !== x || this._y !== y) {
+			this.transform.translate(x - this._x, y - this._y);
+			this._x = x;
+			this._y = y;
+		}
 		this.model.draw(surface);
 	}
 }

--- a/assets/system/game_modules/kami.mjs
+++ b/assets/system/game_modules/kami.mjs
@@ -189,7 +189,7 @@ function makeTable(table, bordered)
 			if (bordered === true)
 				column[j] += "|";
 		}
-		totalLength += (width + 3);
+		totalLength += width + (bordered ? 3 : 2);
 	}
 
 	let start = "\n";

--- a/assets/system/game_modules/prim.mjs
+++ b/assets/system/game_modules/prim.mjs
@@ -30,6 +30,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
 **/
 
+const white = Color.White;
+
 export default
 class Prim
 {
@@ -43,10 +45,8 @@ class Prim
 		Prim.blitSection(surface, x, y, texture, 0, 0, texture.width, texture.height, mask);
 	}
 
-	static blitSection(surface, x, y, texture, sx, sy, width, height, mask)
+	static blitSection(surface, x, y, texture, sx, sy, width, height, mask = white)
 	{
-		mask = mask || Color.White;
-
 		let x1 = x;
 		let y1 = y;
 		let x2 = x1 + width;


### PR DESCRIPTION
1. cache white as most common color object
2. used cached value as default parameter to avoid making new color object on each call
3. cache last used color
4. don't scale - as no scaling api provided so had no purpose
5. cache x and y coordinates

(Also fix minor formatting error in kami.mjs and cache white in prim.mjs as well)