### PR TITLE
Fix a typo in image_load function

### DIFF
--- a/src/minisphere/image.c
+++ b/src/minisphere/image.c
@@ -169,7 +169,7 @@ image_load(const char* filename)
 		file_ext = ".bmp";
 	if (memcmp(first_16, "\211PNG\r\n\032\n", 8) == 0)
 		file_ext = ".png";
-	if (memcmp(first_16, "\0xFF\0xD8", 2) == 0)
+	if (memcmp(first_16, "\xFF\xD8", 2) == 0)
 		file_ext = ".jpg";
 
 	if (!(image->bitmap = al_load_bitmap_flags_f(al_file, file_ext, ALLEGRO_NO_PREMULTIPLIED_ALPHA)))


### PR DESCRIPTION
There's a typo at Line 172 of image.c:
https://github.com/fatcerberus/minisphere/blob/37192851cae922d9db4812d18d9c8853dd2eda7a/src/minisphere/image.c#L172-L173

"\0xFF\0xD8" is `\0 x F F \0 x D 8`. It should be changed to "\xFF\xD8".
