### PR TITLE
Fix integer overflow in layer_resize in map_engine.c

### DIFF
--- a/src/minisphere/map_engine.c
+++ b/src/minisphere/map_engine.c
@@ -1046,7 +1046,8 @@ layer_resize(int layer, int x_size, int y_size)
 	// allocate a new tilemap and copy the old layer tiles into it.  we can't simply realloc
 	// because the tilemap is a 2D array.
 	tilemap_size = x_size * y_size * sizeof(struct map_tile);
-	if (x_size == 0 || tilemap_size / x_size / sizeof(struct map_tile) != y_size || !(tilemap = malloc(tilemap_size)))
+	if (x_size == 0 || tilemap_size / x_size / sizeof(struct map_tile) != y_size
+		|| !(tilemap = malloc(tilemap_size)))
 		return false;
 	for (x = 0; x < x_size; ++x) {
 		for (y = 0; y < y_size; ++y) {

--- a/src/minisphere/map_engine.c
+++ b/src/minisphere/map_engine.c
@@ -1036,6 +1036,7 @@ layer_resize(int layer, int x_size, int y_size)
 	struct map_tile*    tilemap;
 	struct map_trigger* trigger;
 	struct map_zone*    zone;
+	size_t              tilemap_size;
 
 	int x, y, i;
 
@@ -1044,7 +1045,8 @@ layer_resize(int layer, int x_size, int y_size)
 
 	// allocate a new tilemap and copy the old layer tiles into it.  we can't simply realloc
 	// because the tilemap is a 2D array.
-	if (!(tilemap = malloc(x_size * y_size * sizeof(struct map_tile))))
+	tilemap_size = x_size * y_size * sizeof(struct map_tile);
+	if (x_size == 0 || tilemap_size / x_size / sizeof(struct map_tile) != y_size || !(tilemap = malloc(tilemap_size)))
 		return false;
 	for (x = 0; x < x_size; ++x) {
 		for (y = 0; y < y_size; ++y) {


### PR DESCRIPTION
There's a buffer overflow bug in the function layer_resize. It allocates a buffer `tilemap` with size `x_size * y_size * sizeof(struct map_tile)`. But it didn't check for integer overflow, so if x_size and y_size are very large, it's possible that the buffer size is smaller than needed, causing a buffer overflow.

PoC:
`SetLayerSize(0, 0x7FFFFFFF, 0x7FFFFFFF);`