### PR TITLE
Add missing BlendOps to core API documentation

### DIFF
--- a/docs/sphere2-core-api.txt
+++ b/docs/sphere2-core-api.txt
@@ -1696,6 +1696,10 @@ Surface#blendOp [read/write]
 
         BlendOp.AlphaBlend
         BlendOp.Add
+        BlendOp.Average
+        BlendOp.CopyAlpha
+        BlendOp.CopyRGB
+        BlendOp.Invert
         BlendOp.Multiply
         BlendOp.Replace
         BlendOp.Subtract


### PR DESCRIPTION
[pegasus.c](https://github.com/fatcerberus/minisphere/blob/7935bc87446dbc4f2a40f2bda9f3c044e853cd7e/src/minisphere/pegasus.c#L858) defines a number of BlendOps that aren't in the documentation. This PR adds them.