### PR TITLE
Implement awaitable Socket and Server operations

### DIFF
--- a/docs/sphere2-core-api.txt
+++ b/docs/sphere2-core-api.txt
@@ -1566,6 +1566,13 @@ Server#accept(); [L1]
     empty, a RangeError will be thrown, so you should check the value of
     `numPending` first to see if there are any connections in the backlog.
 
+Server#acceptNext(); [ASYNC] [L2]
+
+    Instructs Sphere to accept the next available client connection from the
+    event loop.  The promise resolves with a Socket representing that
+    connection.  This is an asychronous version of `accept()` that can be used
+    with `await`.
+
 Server#close(); [L1]
 
     Shuts down the server.  The server port will be closed and any connections
@@ -1736,6 +1743,12 @@ A `Socket` represents a TCP connection to another computer.  Sockets can either
 be created manually (if the game is initiating the connection), or returned by
 `Server#accept()` to represent an incoming connection.
 
+Socket.connectTo(hostname, port); [ASYNC] [L2]
+
+    Connects to the specified host and port and returns a promise for a newly
+    constructed Socket object for the connection.  If the connection attempt
+    fails, the promise is rejected.
+
 new Socket([hostname, port]); [L1]
 
     Constructs a new socket object.  If `hostname` and `port` are specified,
@@ -1774,18 +1787,26 @@ Socket#remotePort [R/O] [L1]
 
 Socket#close(); [L1]
 
-    Disconnects the socket.  You can reconnect it by calling its `connectTo`
-    method again.
+    Immediately closes the connection.  If there is still data in the socket's
+    write-behind buffer not yet sent over the wire, it will be discarded.  To
+    avoid this, use `disconnect()` instead.
 
-Socket#connectTo(hostname, port); [L1]
+Socket#connectTo(hostname, port); [ASYNC] [L1]
 
     Connects the socket to `hostname` on `port`.  `hostname` can either be a
-    domain name (e.g. google.com) or IP address (e.g. 127.0.0.1).  The socket's
-    `connected` property will become `true` once the connection is established.
+    domain name (e.g. google.com) or IP address (e.g. 127.0.0.1).  The promise
+    resolves when the socket is ready for communication.
 
     Note: A single socket can only be connected to one client at a time.  If
-          the socket is already connected when `Socket#connectTo()` is called,
-          that connection will be closed.
+          the socket is already connected when `connectTo()` is called, the
+          promise will be rejected with a TypeError.
+
+Socket#disconnect(); [ASYNC] [L2]
+
+    Disconnects the socket.  If there is still data in the socket's outgoing
+    write buffer yet to be written, it will be written out before the
+    connection is closed.  The promise resolves when the socket is no longer
+    connected.
 
 Socket#read(num_bytes); [L1]
 
@@ -1795,6 +1816,17 @@ Socket#read(num_bytes); [L1]
     This call is non-blocking; if there is not enough data in the socket's
     receive buffer to satisfy the read, a RangeError will be thrown.  To avoid
     the RangeError, check the value of `bytesPending` first.
+
+Socket#readAsync(num_bytes); [ASYNC] [L2]
+
+    Instructs Sphere to read `num_bytes` from the socket from the event loop.
+    The promise resolves with an ArrayBuffer containing the data read.  This is
+    an asynchronous version of `read()` that can be used with `await`.
+
+    Note: This call will not fail if there is not enough data in the receive
+          buffer to immediately satisfy it.  However, if the connection is lost
+          before the amount of data asked for can be read, Sphere will reject
+          the promise.
 
 Socket#write(data); [L1]
 

--- a/src/minisphere/event_loop.h
+++ b/src/minisphere/event_loop.h
@@ -33,9 +33,15 @@
 #ifndef SPHERE__EVENT_LOOP_H__INCLUDED
 #define SPHERE__EVENT_LOOP_H__INCLUDED
 
+#include "sockets.h"
+
 bool events_exiting        (void);
 int  events_get_frame_rate (void);
 void events_set_frame_rate (int frame_rate);
+void events_accept_client  (server_t* server);
+void events_connect_to     (socket_t* socket, const char* hostname, int port);
+void events_disconnect     (socket_t* socket);
+void events_read_socket    (socket_t* socket, size_t num_bytes);
 bool events_run_main_loop  (void);
 void events_tick           (int api_version, bool clear_screen, int framerate);
 


### PR DESCRIPTION
miniSphere 5.3 is introducing new asynchronous versions of previously synchronous APIs, such as `FileStream` and `Socket`.  FileStream isn't an issue; miniSphere, like Node.js can safely assume a fast file system and perform I/O synchronously, even while returning promises.  Sockets are a different story: for async `read()` or `connectTo()`, it doesn't make much sense to block waiting for things to complete.  This means if networking operations are to be awaitable, they must be handled in the event loop.

For example: The current behavior for `Socket#read` is, as with synchronous sockets, to immediately fail the read if there is not enough data in the receive buffer.  This is unacceptable in an engine that supports promises and async functions; it should be possible to `await socket.read(100)` and have that code path go to sleep until 100 bytes are actually available.  This pull request adds support for exactly that.

#### To-Do List for this change
- [X] Awaitable `Socket.connectTo` - like `new Socket` but async
- [X] Awaitable `socket_obj.connectTo`
- [x] Awaitable `socket_obj.disconnect`
- [X] Awaitable `socket_obj.readAsync`
- [X] Awaitable `server_obj.acceptNext`