### PR TITLE
Fix Makefile compatibility with macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
   - sudo apt-get install -qq liballegro5-dev liballegro-acodec5-dev liballegro-audio5-dev liballegro-dialog5-dev liballegro-image5-dev liballegro-physfs5-dev liballegro-ttf5-dev liballegro-video5-dev
   - sudo apt-get install -qq libmng-dev
   - sudo apt-get install -qq libpng-dev
-script: sudo make deps && make && sudo make install
+script: make deps && sudo make installdeps && make && sudo make install

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ engine_libs= \
    -lallegro_dialog \
    -lallegro_font \
    -lallegro_image \
+   -lallegro_main \
    -lallegro_memfile \
    -lallegro_primitives \
    -lallegro_ttf \
@@ -129,9 +130,7 @@ ssj_sources=src/ssj/main.c \
 
 ifeq ($(os), Darwin)
 LINKER_ARGS=-Wl,-rpath,\$$ORIGIN
-engine_libs+=-lallegro_main
 CHAKRACORE_URL=https://aka.ms/chakracore/cc_osx_x64_1_11_15
-
 else
 LINKER_ARGS=-Wl,-rpath=\$$ORIGIN
 OPTIONS=-DMINISPHERE_MNG_SUPPORT


### PR DESCRIPTION
Adds some logic to handle the differences when building on macOS. MNG
support is disabled due to the difficulty of obtaining it on that
platform.