### PR TITLE
Fix shader uniform memory leaks

### DIFF
--- a/src/minisphere/galileo.c
+++ b/src/minisphere/galileo.c
@@ -409,8 +409,8 @@ shader_ref(shader_t* it)
 void
 shader_unref(shader_t* it)
 {
-	struct uniform *uniform;
-	iter_t iter;
+	struct uniform* uniform;
+	iter_t          iter;
 
 	if (it == NULL || --it->refcount > 0)
 		return;
@@ -419,8 +419,7 @@ shader_unref(shader_t* it)
 
 	iter = vector_enum(it->uniforms);
 	while ((uniform = iter_next(&iter))) {
-		switch (uniform->type)
-		{
+		switch (uniform->type) {
 		case UNIFORM_FLOAT_ARR:
 			free(uniform->float_list);
 			break;

--- a/src/minisphere/galileo.c
+++ b/src/minisphere/galileo.c
@@ -410,6 +410,7 @@ void
 shader_unref(shader_t* it)
 {
 	struct uniform* uniform;
+
 	iter_t          iter;
 
 	if (it == NULL || --it->refcount > 0)


### PR DESCRIPTION
Free memory for int and float array uniforms when the uniform or shader is destroyed.