### PR TITLE
Add support for multisample antialiasing

### DIFF
--- a/docs/sphere2-core-api.txt
+++ b/docs/sphere2-core-api.txt
@@ -2179,7 +2179,7 @@ new Surface(width, height[, options]); [NEW]
         The number of samples to use for multisample antialiasing. The default
         value is 0, which means multisampling is not enabled. A value of 1
         would mean one sample per pixel, effectively the same as not being
-        enabled. Normal values would be 4 or 8.
+        enabled. Normal values would be multiples of 2.
 
         This effectively multiplies the resolution of the texture by the value
         you choose internally, so can have a large effect on performance and
@@ -2324,7 +2324,7 @@ new Texture(width, height[, options]); [NEW]
         The number of samples to use for multisample antialiasing. The default
         value is 0, which means multisampling is not enabled. A value of 1
         would mean one sample per pixel, effectively the same as not being
-        enabled. Normal values would be 4 or 8.
+        enabled. Normal values would be multiples of 2.
 
         This effectively multiplies the resolution of the texture by the value
         you choose internally, so can have a large effect on performance and

--- a/docs/sphere2-core-api.txt
+++ b/docs/sphere2-core-api.txt
@@ -2159,6 +2159,34 @@ new Surface(width, height[, content]); [API 1]
           enough pixel data to cover the entire surface, a RangeError will be
           thrown.
 
+new Surface(width, height[, options]); [NEW]
+
+    Constructs a new Surface with the specified options. `width` and `height`
+    specify the size in pixels of the surface.
+
+    The following are all optional:
+
+    options.color
+        A `Color` with which the surface will be filled. The default is
+        `Color.Transparent`.
+
+    options.content:
+        A buffer object holding the RGBA pixel data to use to initialize the
+        image. The pixel data should not be padded (i.e. stride equal to
+        width).
+
+    options.multisample
+        The number of samples to use for multisample antialiasing. The default
+        value is 0, which means multisampling is not enabled. A value of 1
+        would mean one sample per pixel, effectively the same as not being
+        enabled. Normal values would be 4 or 8.
+
+        This effectively multiplies the resolution of the texture by the value
+        you choose internally, so can have a large effect on performance and
+        texture size.
+
+    If `content` is specified, both `color` and `multisample` will be ignored.
+
 new Surface(filename); [API 1]
 
     Loads the image file named by `filename` synchronously, without yielding to
@@ -2275,6 +2303,34 @@ new Texture(width, height[, content]); [API 1]
     Note: When passing a buffer for `content` and the buffer doesn't contain
           enough pixel data to cover the entire texture, a RangeError will be
           thrown.
+
+new Texture(width, height[, options]); [NEW]
+
+    Constructs a new Texture with the specified options. `width` and `height`
+    specify the size in pixels of the surface.
+
+    The following are all optional:
+
+    options.color
+        A `Color` with which the texture will be filled. The default is
+        `Color.Transparent`.
+
+    options.content:
+        A buffer object holding the RGBA pixel data to use to initialize the
+        image. The pixel data should not be padded (i.e. stride equal to
+        width).
+
+    options.multisample
+        The number of samples to use for multisample antialiasing. The default
+        value is 0, which means multisampling is not enabled. A value of 1
+        would mean one sample per pixel, effectively the same as not being
+        enabled. Normal values would be 4 or 8.
+
+        This effectively multiplies the resolution of the texture by the value
+        you choose internally, so can have a large effect on performance and
+        texture size.
+
+    If `content` is specified, both `color` and `multisample` will be ignored.
 
 new Texture(surface); [API 1]
 

--- a/src/minisphere/animation.c
+++ b/src/minisphere/animation.c
@@ -221,7 +221,7 @@ mng_cb_processheader(mng_handle stream, mng_uint32 width, mng_uint32 height)
 	anim->w = width;
 	anim->h = height;
 	image_unref(anim->frame);
-	if (!(anim->frame = image_new(anim->w, anim->h, NULL)))
+	if (!(anim->frame = image_new(anim->w, anim->h, NULL, 0)))
 		goto on_error;
 	mng_set_canvasstyle(stream, MNG_CANVAS_RGBA8);
 	return MNG_TRUE;

--- a/src/minisphere/atlas.c
+++ b/src/minisphere/atlas.c
@@ -61,7 +61,7 @@ atlas_new(int num_images, int max_width, int max_height)
 	atlas->max_width = max_width;
 	atlas->max_height = max_height;
 	atlas->size = mk_rect(0, 0, atlas->pitch * atlas->max_width, atlas->pitch * atlas->max_height);
-	if (!(atlas->image = image_new(atlas->size.x2, atlas->size.y2, NULL)))
+	if (!(atlas->image = image_new(atlas->size.x2, atlas->size.y2, NULL, 0)))
 		goto on_error;
 
 	atlas->id = s_next_atlas_id++;

--- a/src/minisphere/font.c
+++ b/src/minisphere/font.c
@@ -159,7 +159,7 @@ font_load(const char* filename)
 	n_glyphs_per_row = ceil(sqrt(rfn.num_chars));
 	atlas_size_x = max_x * n_glyphs_per_row;
 	atlas_size_y = max_y * n_glyphs_per_row;
-	if ((atlas = image_new(atlas_size_x, atlas_size_y, NULL)) == NULL)
+	if ((atlas = image_new(atlas_size_x, atlas_size_y, NULL, 0)) == NULL)
 		goto on_error;
 
 	// pass 2: load glyph data

--- a/src/minisphere/galileo.c
+++ b/src/minisphere/galileo.c
@@ -409,10 +409,27 @@ shader_ref(shader_t* it)
 void
 shader_unref(shader_t* it)
 {
+	struct uniform* uniform;
+
+	iter_t          iter;
+
 	if (it == NULL || --it->refcount > 0)
 		return;
 
 	console_log(3, "disposing shader program #%u no longer in use", it->id);
+
+	iter = vector_enum(it->uniforms);
+	while ((uniform = iter_next(&iter))) {
+		switch (uniform->type) {
+		case UNIFORM_FLOAT_ARR:
+			free(uniform->float_list);
+			break;
+		case UNIFORM_INT_ARR:
+			free(uniform->int_list);
+			break;
+		}
+	}
+
 	al_destroy_shader(it->program);
 	vector_free(it->uniforms);
 	free(it);
@@ -831,8 +848,18 @@ free_cached_uniform(shader_t* shader, const char* name)
 
 	iter = vector_enum(shader->uniforms);
 	while ((uniform = iter_next(&iter))) {
-		if (strcmp(uniform->name, name) == 0)
+		if (strcmp(uniform->name, name) == 0) {
+			switch (uniform->type) {
+			case UNIFORM_FLOAT_ARR:
+				free(uniform->float_list);
+				break;
+			case UNIFORM_INT_ARR:
+				free(uniform->int_list);
+				break;
+			}
+
 			iter_remove(&iter);
+		}
 	}
 }
 

--- a/src/minisphere/image.c
+++ b/src/minisphere/image.c
@@ -67,7 +67,7 @@ static image_t*     s_last_image = NULL;
 static unsigned int s_next_image_id = 0;
 
 image_t*
-image_new(int width, int height, const color_t* pixels)
+image_new(int width, int height, const color_t* pixels, int multisample)
 {
 	image_t*        image;
 	ALLEGRO_BITMAP* old_target;
@@ -76,6 +76,7 @@ image_new(int width, int height, const color_t* pixels)
 	if (!(image = calloc(1, sizeof(image_t))))
 		goto on_error;
 	al_set_new_bitmap_depth(16);
+	al_set_new_bitmap_samples(multisample);
 	if ((image->bitmap = al_create_bitmap(width, height)) == NULL)
 		goto on_error;
 	image->id = s_next_image_id++;

--- a/src/minisphere/image.h
+++ b/src/minisphere/image.h
@@ -61,7 +61,7 @@ struct image_lock
 	ptrdiff_t pitch;
 } image_lock_t;
 
-image_t*        image_new                (int width, int height, const color_t* pixels);
+image_t*        image_new                (int width, int height, const color_t* pixels, int multisample);
 image_t*        image_new_slice          (image_t* parent, int x, int y, int width, int height);
 image_t*        image_dup                (const image_t* it);
 image_t*        image_load               (const char* filename);

--- a/src/minisphere/screen.c
+++ b/src/minisphere/screen.c
@@ -110,7 +110,7 @@ screen_new(const char* title, image_t* icon, size2_t resolution, int frameskip, 
 		// and the screen-grab functions.
 		al_store_state(&old_state, ALLEGRO_STATE_NEW_BITMAP_PARAMETERS);
 		al_set_new_bitmap_format(ALLEGRO_PIXEL_FORMAT_ANY_24_NO_ALPHA);
-		backbuffer = image_new(resolution.width, resolution.height, NULL);
+		backbuffer = image_new(resolution.width, resolution.height, NULL, 0);
 		al_restore_state(&old_state);
 	}
 	if (backbuffer == NULL) {
@@ -444,7 +444,7 @@ screen_grab(screen_t* it, int x, int y, int width, int height)
 {
 	image_t* image;
 
-	if (!(image = image_new(width, height, NULL)))
+	if (!(image = image_new(width, height, NULL, 0)))
 		goto on_error;
 	image_render_to(image, NULL);
 	al_draw_bitmap_region(image_bitmap(it->backbuffer), x, y, width, height, 0, 0, 0x0);

--- a/src/minisphere/utility.c
+++ b/src/minisphere/utility.c
@@ -135,7 +135,7 @@ fread_image(file_t* file, int width, int height)
 
 	console_log(3, "reading %dx%d image from open file", width, height);
 	file_pos = file_position(file);
-	if (!(image = image_new(width, height, NULL)))
+	if (!(image = image_new(width, height, NULL, 0)))
 		goto on_error;
 	if (!(lock = image_lock(image, true, false)))
 		goto on_error;

--- a/src/minisphere/vanilla.c
+++ b/src/minisphere/vanilla.c
@@ -2066,7 +2066,7 @@ js_CreateSpriteset(int num_args, bool is_ctor, intptr_t magic)
 
 	spriteset = spriteset_new();
 	spriteset_set_base(spriteset, mk_rect(0, 0, width, height));
-	image = image_new(width, height, NULL);
+	image = image_new(width, height, NULL, 0);
 	for (i = 0; i < num_images; ++i) {
 		// use the same image in all slots to save memory.  this works because
 		// images are read-only, so it doesn't matter that they all share the same
@@ -2126,7 +2126,7 @@ js_CreateSurface(int num_args, bool is_ctor, intptr_t magic)
 	height = jsal_to_int(1);
 	fill_color = num_args >= 3 ? jsal_require_sphere_color(2) : mk_color(0, 0, 0, 0);
 
-	if (!(image = image_new(width, height, NULL)))
+	if (!(image = image_new(width, height, NULL, 0)))
 		jsal_error(JS_ERROR, "Couldn't create GPU texture");
 	image_fill(image, fill_color, 1.0f);
 	jsal_push_class_obj(SV1_SURFACE, image, false);
@@ -8506,7 +8506,7 @@ js_Surface_cloneSection(int num_args, bool is_ctor, intptr_t magic)
 	width = jsal_to_int(2);
 	height = jsal_to_int(3);
 
-	if (!(new_image = image_new(width, height, NULL)))
+	if (!(new_image = image_new(width, height, NULL, 0)))
 		jsal_error(JS_ERROR, "couldn't create surface");
 	image_render_to(new_image, NULL);
 	al_clear_to_color(al_map_rgba(0, 0, 0, 0));
@@ -9045,7 +9045,7 @@ js_Surface_rotate(int num_args, bool is_ctor, intptr_t magic)
 		// FIXME: implement in-place resizing for Surface#rotate()
 		jsal_error(JS_ERROR, "Resizing not implemented for Surface#rotate()");
 	}
-	if (!(new_image = image_new(new_width, new_height, NULL)))
+	if (!(new_image = image_new(new_width, new_height, NULL, 0)))
 		jsal_error(JS_ERROR, "Couldn't create new surface");
 	image_render_to(new_image, NULL);
 	al_clear_to_color(al_map_rgba(0, 0, 0, 0));


### PR DESCRIPTION
Adds a new signature for texture constructors that accepts an object for the third argument so that textures can be constructed with a color or buffer and multisampling.

```
new Texture(width, height[, options]); [NEW]

    Constructs a new Texture with the specified options. `width` and `height`
    specify the size in pixels of the surface.

    The following are all optional:

    options.color
        A `Color` with which the texture will be filled. The default is
        `Color.Transparent`.

    options.content:
        A buffer object holding the RGBA pixel data to use to initialize the
        image. The pixel data should not be padded (i.e. stride equal to
        width).

    options.multisample
        The number of samples to use for multisample antialiasing. The default
        value is 0, which means multisampling is not enabled. A value of 1
        would mean one sample per pixel, effectively the same as not being
        enabled. Normal values would be multiples of 2.

        This effectively multiplies the resolution of the texture by the value
        you choose internally, so can have a large effect on performance and
        texture size.

    If `content` is specified, both `color` and `multisample` will be ignored.
```

Multisampling has to be ignored if content is provided because the underlying buffer seems to change. (I got graphical glitches when I tried)